### PR TITLE
Hotfix kubernetes cni

### DIFF
--- a/scripts/install-kubeadm
+++ b/scripts/install-kubeadm
@@ -7,6 +7,6 @@ cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
 deb https://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -qy kubelet=1.14.0-00 kubeadm=1.14.0-00 kubectl=1.14.0-00
+apt-get install -qy kubernetes-cni=0.7.5-00 kubelet=1.14.0-00 kubeadm=1.14.0-00 kubectl=1.14.0-00
 apt-get install -y glusterfs-client
 apt-mark hold kubelet kubeadm kubectl


### PR DESCRIPTION
Trying to deploy the cluster from scratch I got the following error:
```
 node-1: /tmp/vagrant-shell: line 26: kubeadm: command not found
```

looking back on the installation I saw the following trace:

```
 node-1: The following packages have unmet dependencies:
 node-1:  kubeadm : Depends: kubernetes-cni (= 0.7.5)
 node-1:  kubelet : Depends: kubernetes-cni (= 0.7.5)
 node-1: E: Unable to correct problems, you have held broken packages.
```

All in all I just needed to fix the version of kubernetes-cni so it knew which to grab. After this, `vagrant up` worked with no problems.